### PR TITLE
Tighten types: LayerStatus literal, parameterize generics, rename result→proc

### DIFF
--- a/src/ee_preflight/layers/galaxy.py
+++ b/src/ee_preflight/layers/galaxy.py
@@ -72,7 +72,7 @@ def validate(ctx: ValidateContext) -> tuple[LayerResult, list[Finding], set[str]
 
     for attempt in range(MAX_RETRIES):
         try:
-            result = subprocess.run(
+            proc = subprocess.run(
                 [
                     "ade",
                     "install",
@@ -98,12 +98,12 @@ def validate(ctx: ValidateContext) -> tuple[LayerResult, list[Finding], set[str]
             )
             return LayerResult(name="galaxy", status="fail", findings=findings), [], set()
 
-        output = result.stdout + result.stderr
+        output = proc.stdout + proc.stderr
         collections_installed = "Installed collections include:" in output
 
-        if result.returncode == 0 or collections_installed:
+        if proc.returncode == 0 or collections_installed:
             installed = _count_collections(output)
-            if result.returncode != 0:
+            if proc.returncode != 0:
                 python_build_findings, failed_pkgs = _parse_python_build_errors(output)
             else:
                 python_build_findings, failed_pkgs = [], set()

--- a/src/ee_preflight/layers/prechecks.py
+++ b/src/ee_preflight/layers/prechecks.py
@@ -16,7 +16,7 @@ import re
 import shutil
 import subprocess
 
-from ..models import Finding, LayerResult, Severity, ValidateContext
+from ..models import Finding, LayerResult, LayerStatus, Severity, ValidateContext
 
 
 def validate(ctx: ValidateContext) -> LayerResult:
@@ -36,7 +36,7 @@ def validate(ctx: ValidateContext) -> LayerResult:
     _check_base_image(ctx, findings)
 
     has_missing_files = any(f.severity == Severity.ERROR and "not found" in f.message for f in findings)
-    status = "fail" if has_missing_files else "pass"
+    status: LayerStatus = "fail" if has_missing_files else "pass"
 
     return LayerResult(name="prechecks", status=status, findings=findings)
 
@@ -62,14 +62,14 @@ def _check_ansible_lint(ctx: ValidateContext, findings: list[Finding]) -> None:
         return
 
     try:
-        result = subprocess.run(
+        proc = subprocess.run(
             ["ansible-lint", str(ctx.ee.path)],
             capture_output=True,
             text=True,
             timeout=30,
         )
-        if result.returncode != 0:
-            for line in result.stdout.splitlines():
+        if proc.returncode != 0:
+            for line in proc.stdout.splitlines():
                 if ctx.ee.path.name in line and "]" in line:
                     findings.append(
                         Finding(

--- a/src/ee_preflight/layers/python_deps.py
+++ b/src/ee_preflight/layers/python_deps.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import re
 
-from ..models import DepFormat, Finding, LayerResult, Severity, ValidateContext
+from ..models import DepFormat, Finding, LayerResult, LayerStatus, Severity, ValidateContext
 
 ADE_ENV_DIR = ".ansible-dev-environment"
 DISCOVERED_PYTHON = "discovered_requirements.txt"
@@ -52,7 +52,7 @@ def validate(ctx: ValidateContext) -> LayerResult:
     _diff_python_deps(ctx, discovered_python, findings)
     _diff_system_deps(ctx, discovered_system, findings)
 
-    status = "fail" if any(f.severity == Severity.ERROR for f in findings) else "pass"
+    status: LayerStatus = "fail" if any(f.severity == Severity.ERROR for f in findings) else "pass"
     return LayerResult(name="python_deps", status=status, findings=findings)
 
 

--- a/src/ee_preflight/layers/system_deps.py
+++ b/src/ee_preflight/layers/system_deps.py
@@ -18,7 +18,7 @@ import re
 
 from ..cache import DependencyCache
 from ..container import ContainerRuntime
-from ..models import Finding, LayerResult, Severity, ValidateContext
+from ..models import Finding, LayerResult, LayerStatus, Severity, ValidateContext
 
 # Patterns for extracting missing files/dependencies from wheel build errors
 MISSING_FILE_PATTERNS = [
@@ -71,12 +71,12 @@ def validate(ctx: ValidateContext, extra_packages: set[str] | None = None) -> La
         )
     )
 
-    pull_result = runtime.pull(image)
-    if pull_result.returncode != 0:
+    pull_proc = runtime.pull(image)
+    if pull_proc.returncode != 0:
         findings.append(
             Finding(
                 severity=Severity.ERROR,
-                message=f"Failed to pull base image: {pull_result.stderr.strip()}",
+                message=f"Failed to pull base image: {pull_proc.stderr.strip()}",
             )
         )
         return LayerResult(name="system_deps", status="fail", findings=findings)
@@ -172,7 +172,7 @@ def validate(ctx: ValidateContext, extra_packages: set[str] | None = None) -> La
 
     findings.extend(all_pkg_findings)
 
-    status = "fail" if any(f.severity == Severity.ERROR for f in findings) else "pass"
+    status: LayerStatus = "fail" if any(f.severity == Severity.ERROR for f in findings) else "pass"
     return LayerResult(name="system_deps", status=status, findings=findings)
 
 
@@ -188,12 +188,12 @@ def _detect_python_version(runtime: ContainerRuntime, image: str) -> str:
     Returns:
         Python version string (e.g., "3.11" or "3" if detection fails)
     """
-    result = runtime.run(
+    proc = runtime.run(
         image,
         "python3 -c 'import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")'",
     )
-    if result.returncode == 0:
-        return str(result.stdout.strip())
+    if proc.returncode == 0:
+        return str(proc.stdout.strip())
     return "3"
 
 
@@ -339,10 +339,10 @@ def _test_wheel_build(
         f"{pycmd} -m pip wheel --no-binary :all: '{pkg}' -w /tmp/wheels"
     )
 
-    result = runtime.run(image, cmd, timeout=180)
+    proc = runtime.run(image, cmd, timeout=180)
     findings: list[Finding] = []
 
-    if result.returncode == 0:
+    if proc.returncode == 0:
         findings.append(
             Finding(
                 severity=Severity.INFO,
@@ -351,7 +351,7 @@ def _test_wheel_build(
         )
         return findings, None
 
-    output = result.stdout + result.stderr
+    output = proc.stdout + proc.stderr
     missing_file = _extract_missing_file(output)
 
     if missing_file:
@@ -455,14 +455,14 @@ def _find_providing_package(
 
     # Try dnf provides inside the container (install dnf if needed)
     search = f"*/pkgconfig/{missing_file}.pc" if "." not in missing_file else f"*/{missing_file}"
-    result = runtime.run(
+    proc = runtime.run(
         image,
         f"(microdnf install -y dnf 2>/dev/null || true) && dnf provides '{search}' 2>/dev/null",
         timeout=120,
     )
-    if result.returncode == 0 and result.stdout.strip():
+    if proc.returncode == 0 and proc.stdout.strip():
         candidates: list[str] = []
-        for line in result.stdout.splitlines():
+        for line in proc.stdout.splitlines():
             line = line.strip()
             skip_prefixes = ("Last", "=", "Repo", "Matched", "Filename", "Provide")
             if not line or any(line.startswith(p) for p in skip_prefixes):
@@ -480,13 +480,13 @@ def _find_providing_package(
 
     # Try apt-file for Debian-based containers
     if not resolved_rpm:
-        result = runtime.run(
+        proc = runtime.run(
             image,
             f"apt-file search '{missing_file}' 2>/dev/null | head -1",
             timeout=60,
         )
-        if result.returncode == 0 and result.stdout.strip():
-            pkg = str(result.stdout.strip().split(":")[0])
+        if proc.returncode == 0 and proc.stdout.strip():
+            pkg = str(proc.stdout.strip().split(":")[0])
             if pkg:
                 resolved_rpm = pkg
 

--- a/src/ee_preflight/models.py
+++ b/src/ee_preflight/models.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
+from typing import Any, Literal
+
+LayerStatus = Literal["pass", "fail", "skipped"]
 
 
 class Severity(Enum):
@@ -43,7 +46,7 @@ class Finding:
     fix: str | None = None
     source: str | None = None
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, str | None]:
         """Convert to dictionary for JSON serialization."""
         return {
             "severity": self.severity.value,
@@ -64,7 +67,7 @@ class LayerResult:
     """
 
     name: str
-    status: str
+    status: LayerStatus
     findings: list[Finding] = field(default_factory=list)
 
     @property
@@ -72,7 +75,7 @@ class LayerResult:
         """Check if this layer has any ERROR-level findings."""
         return any(f.severity == Severity.ERROR for f in self.findings)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
         return {
             "name": self.name,
@@ -104,7 +107,7 @@ class DepRef:
 
     format: DepFormat
     file_path: Path | None = None
-    entries: list = field(default_factory=list)
+    entries: list[str | dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass
@@ -132,10 +135,10 @@ class EEDefinition:
     galaxy: DepRef | None = None
     python: DepRef | None = None
     system: DepRef | None = None
-    build_steps: dict = field(default_factory=dict)
-    build_files: list = field(default_factory=list)
-    options: dict = field(default_factory=dict)
-    raw: dict = field(default_factory=dict)
+    build_steps: dict[str, list[str]] = field(default_factory=dict)
+    build_files: list[dict[str, str]] = field(default_factory=list)
+    options: dict[str, Any] = field(default_factory=dict)
+    raw: dict[str, Any] = field(default_factory=dict)
 
     @property
     def build_args(self) -> list[str]:

--- a/src/ee_preflight/runner.py
+++ b/src/ee_preflight/runner.py
@@ -237,7 +237,7 @@ def _run_build(ee: EEDefinition, tag: str | None) -> LayerResult:
             cmd.extend(["--build-arg", f"{arg_name}={val}"])
 
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
     except subprocess.TimeoutExpired:
         return LayerResult(
             name="build",
@@ -250,7 +250,7 @@ def _run_build(ee: EEDefinition, tag: str | None) -> LayerResult:
             ],
         )
 
-    if result.returncode == 0:
+    if proc.returncode == 0:
         return LayerResult(
             name="build",
             status="pass",
@@ -268,7 +268,7 @@ def _run_build(ee: EEDefinition, tag: str | None) -> LayerResult:
         findings=[
             Finding(
                 severity=Severity.ERROR,
-                message=f"Build failed: {result.stderr[-300:]}",
+                message=f"Build failed: {proc.stderr[-300:]}",
             )
         ],
     )


### PR DESCRIPTION
## Summary
- Added `LayerStatus = Literal["pass", "fail", "skipped"]` for type-safe status values
- Parameterized all bare `dict`/`list` on `EEDefinition` and `DepRef`
- Renamed `result` → `proc` for `subprocess.CompletedProcess` variables across 5 files
- Tightened `to_dict()` return types

## Test plan
- [ ] `mypy src/ee_preflight/` — passes
- [ ] `ruff check src/ee_preflight/` — clean
- [ ] `pytest tests/unit/ -v` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)