### PR TITLE
Add structured finding codes, replace string matching in runner/prechecks

### DIFF
--- a/src/ee_preflight/layers/galaxy.py
+++ b/src/ee_preflight/layers/galaxy.py
@@ -288,6 +288,7 @@ def _parse_collection_errors(output: str) -> list[Finding]:
                     Finding(
                         severity=Severity.ERROR,
                         message=f"Collection conflict: {line[2:]}",
+                        code="collection_conflict",
                     )
                 )
 
@@ -297,6 +298,7 @@ def _parse_collection_errors(output: str) -> list[Finding]:
                 severity=Severity.ERROR,
                 message="Galaxy/Automation Hub authentication failed",
                 fix="Check AH_TOKEN or ansible.cfg credentials",
+                code="auth_failure",
             )
         )
 

--- a/src/ee_preflight/layers/prechecks.py
+++ b/src/ee_preflight/layers/prechecks.py
@@ -35,7 +35,7 @@ def validate(ctx: ValidateContext) -> LayerResult:
     _check_build_args(ctx, findings)
     _check_base_image(ctx, findings)
 
-    has_missing_files = any(f.severity == Severity.ERROR and "not found" in f.message for f in findings)
+    has_missing_files = any(f.code == "missing_file" for f in findings)
     status: LayerStatus = "fail" if has_missing_files else "pass"
 
     return LayerResult(name="prechecks", status=status, findings=findings)
@@ -104,6 +104,7 @@ def _check_file_refs(ctx: ValidateContext, findings: list[Finding]) -> None:
                     severity=Severity.ERROR,
                     message=f"Dependency file not found: {dep_ref.file_path.name}",
                     fix=f"Create {dep_ref.file_path.name} in {ctx.ee.ee_dir}",
+                    code="missing_file",
                 )
             )
 

--- a/src/ee_preflight/layers/system_deps.py
+++ b/src/ee_preflight/layers/system_deps.py
@@ -365,6 +365,7 @@ def _test_wheel_build(
                     message=f"{pkg_name} failed to build: {missing_file} not found",
                     fix=f"Add '{pkg_provider}' to bindep.txt",
                     source=f"required by {pkg_name}",
+                    code="missing_system_dep",
                 )
             )
             return findings, pkg_provider
@@ -375,6 +376,7 @@ def _test_wheel_build(
                     message=f"{pkg_name} failed to build: {missing_file} not found",
                     fix=f"Find the package providing {missing_file} for your base image and add it to bindep.txt",
                     source=f"required by {pkg_name}",
+                    code="missing_system_dep",
                 )
             )
             return findings, None
@@ -384,6 +386,7 @@ def _test_wheel_build(
                 severity=Severity.ERROR,
                 message=f"{pkg_name} failed to build",
                 source=f"pip wheel output: {output[-300:]}",
+                code="build_failure",
             )
         )
         return findings, None

--- a/src/ee_preflight/models.py
+++ b/src/ee_preflight/models.py
@@ -45,15 +45,19 @@ class Finding:
     message: str
     fix: str | None = None
     source: str | None = None
+    code: str | None = None
 
     def to_dict(self) -> dict[str, str | None]:
         """Convert to dictionary for JSON serialization."""
-        return {
+        d = {
             "severity": self.severity.value,
             "message": self.message,
             "fix": self.fix,
             "source": self.source,
         }
+        if self.code:
+            d["code"] = self.code
+        return d
 
 
 @dataclass

--- a/src/ee_preflight/runner.py
+++ b/src/ee_preflight/runner.py
@@ -88,7 +88,7 @@ def run(
         # Layer 0: Pre-checks
         r0 = prechecks.validate(ctx)
         results.append(r0)
-        missing_files = any(f.severity == Severity.ERROR and "not found" in f.message for f in r0.findings)
+        missing_files = any(f.code == "missing_file" for f in r0.findings)
 
         # Skip downstream layers if required files are missing
         if missing_files:


### PR DESCRIPTION
## Summary
- Added optional `code` field to `Finding` dataclass
- Replaced fragile `"not found" in f.message` string matching with `f.code == "missing_file"` in runner.py and prechecks.py
- Added finding codes: `missing_file`, `collection_conflict`, `auth_failure`, `missing_system_dep`, `build_failure`
- Codes are included in JSON output when set

## Test plan
- [ ] `mypy src/ee_preflight/` — passes
- [ ] `ruff check src/ee_preflight/` — clean
- [ ] `pytest tests/unit/ -v` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)