### PR TITLE
Deduplicate pkg_name and missing_file_patterns, rename collection_errors

### DIFF
--- a/src/ee_preflight/fixer.py
+++ b/src/ee_preflight/fixer.py
@@ -15,7 +15,7 @@ import re
 
 import yaml
 
-from .models import DepFormat, EEDefinition, Finding
+from .models import DepFormat, EEDefinition, Finding, pkg_name
 
 
 def apply_fixes(ee: EEDefinition, findings: list[Finding]) -> list[str]:
@@ -126,9 +126,9 @@ def _add_python_deps(ee: EEDefinition, entries: list[str], changes: list[str]) -
     if ee.python and ee.python.format == DepFormat.FILE and ee.python.file_path:
         existing = ee.python.file_path.read_text() if ee.python.file_path.exists() else ""
         existing_names = {
-            _pkg_name(line) for line in existing.splitlines() if line.strip() and not line.startswith("#")
+            pkg_name(line) for line in existing.splitlines() if line.strip() and not line.startswith("#")
         }
-        new_entries = [e for e in entries if _pkg_name(e) not in existing_names]
+        new_entries = [e for e in entries if pkg_name(e) not in existing_names]
         if new_entries:
             with open(ee.python.file_path, "a") as f:
                 for entry in new_entries:
@@ -312,20 +312,3 @@ def _add_inline_deps(ee: EEDefinition, dep_type: str, entries: list[str], change
 
     ee.path.write_text("".join(lines))
     changes.append(f"Added to {ee.path.name} [{dep_type}]: {', '.join(new_entries)}")
-
-
-def _pkg_name(spec: str) -> str:
-    """Extract the package name from a Python requirement specifier.
-
-    Strips version constraints, extras, and environment markers to get the
-    base package name. Normalizes hyphens to underscores for comparison.
-
-    Args:
-        spec: Python requirement spec (e.g., "pkg>=1.0[extra];python_version>'3.8'")
-
-    Returns:
-        Normalized package name (e.g., "pkg")
-    """
-    for sep in (">=", "<=", "==", "!=", ">", "<", "[", ";"):
-        spec = spec.split(sep)[0]
-    return spec.strip().lower().replace("-", "_")

--- a/src/ee_preflight/layers/galaxy.py
+++ b/src/ee_preflight/layers/galaxy.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import yaml
 
 from ..models import DepFormat, Finding, LayerResult, Severity, ValidateContext
+from .system_deps import MISSING_FILE_PATTERNS
 
 # Network errors that should trigger retry with backoff
 TRANSIENT_PATTERNS = [
@@ -135,11 +136,11 @@ def validate(ctx: ValidateContext) -> tuple[LayerResult, list[Finding], set[str]
             continue
 
         # Separate collection errors from Python build failures
-        collection_errors = _parse_collection_errors(output)
+        collection_findings = _parse_collection_errors(output)
         python_build_findings, failed_pkgs = _parse_python_build_errors(output)
 
-        if collection_errors:
-            findings.extend(collection_errors)
+        if collection_findings:
+            findings.extend(collection_findings)
             return LayerResult(name="galaxy", status="fail", findings=findings), [], set()
 
         if python_build_findings:
@@ -336,16 +337,8 @@ def _parse_python_build_errors(output: str) -> tuple[list[Finding], set[str]]:
         for match in re.finditer(pattern, output):
             failed_pkgs.add(match.group(1).lower().replace("-", "_"))
 
-    # Patterns for identifying missing files/dependencies
-    missing_file_patterns = [
-        (r"fatal error: (\S+\.h): No such file or directory", "header"),
-        (r"(\S+): command not found", "command"),
-        (r"Package '(\S+)' not found", "pkgconfig"),
-        (r"Package (\S+) was not found in the pkg-config search path", "pkgconfig"),
-    ]
-
     seen: set[str] = set()
-    for pattern, kind in missing_file_patterns:
+    for pattern, kind in MISSING_FILE_PATTERNS:
         for match in re.finditer(pattern, output):
             missing = match.group(1)
             if missing in seen:

--- a/src/ee_preflight/layers/python_deps.py
+++ b/src/ee_preflight/layers/python_deps.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import re
 
-from ..models import DepFormat, Finding, LayerResult, LayerStatus, Severity, ValidateContext
+from ..models import DepFormat, Finding, LayerResult, Severity, ValidateContext, pkg_name
 
 ADE_ENV_DIR = ".ansible-dev-environment"
 DISCOVERED_PYTHON = "discovered_requirements.txt"
@@ -144,11 +144,11 @@ def _diff_python_deps(
         findings: List to append findings to
     """
     declared = _read_declared_python(ctx)
-    declared_names = {_pkg_name(d) for d in declared}
+    declared_names = {pkg_name(d) for d in declared}
 
     seen: set[str] = set()
     for entry in discovered:
-        name = _pkg_name(entry["dep"])
+        name = pkg_name(entry["dep"])
         if not name or name in declared_names or name in seen:
             continue
         seen.add(name)
@@ -315,20 +315,3 @@ def _read_declared_system(ctx: ValidateContext) -> list[str]:
     if ctx.ee.system.format == DepFormat.INLINE:
         return [str(e) for e in ctx.ee.system.entries]
     return []
-
-
-def _pkg_name(spec: str) -> str:
-    """Extract package name from Python requirement spec.
-
-    Strips version constraints, extras, and environment markers.
-    Normalizes hyphens to underscores for comparison.
-
-    Args:
-        spec: Python requirement spec (e.g., "pkg>=1.0[extra];python_version>'3.8'")
-
-    Returns:
-        Normalized package name (e.g., "pkg")
-    """
-    for sep in (">=", "<=", "==", "!=", ">", "<", "[", ";"):
-        spec = spec.split(sep)[0]
-    return spec.strip().lower().replace("-", "_")

--- a/src/ee_preflight/models.py
+++ b/src/ee_preflight/models.py
@@ -183,3 +183,10 @@ class ValidateContext:
     use_cache: bool = True
     cache_path: Path | None = None
     runtime: str | None = None
+
+
+def pkg_name(spec: str) -> str:
+    """Normalize a Python package specifier to a comparable name."""
+    for sep in (">=", "<=", "==", "!=", ">", "<", "[", ";"):
+        spec = spec.split(sep)[0]
+    return spec.strip().lower().replace("-", "_")


### PR DESCRIPTION
## Summary
- Moved `pkg_name()` to `models.py` as single source of truth (was duplicated in python_deps.py and fixer.py)
- Galaxy.py now imports `MISSING_FILE_PATTERNS` from system_deps.py instead of defining a subset copy
- Renamed `collection_errors` → `collection_findings` in galaxy.py for consistency with `Finding` type

## Test plan
- [ ] `mypy src/ee_preflight/` — passes
- [ ] `ruff check src/ee_preflight/` — clean
- [ ] `pytest tests/unit/ -v` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)